### PR TITLE
Deprecated query hooks

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -117,8 +117,7 @@ class Plugin {
 
 		add_action( 'elementor/element/portfolio/section_query/after_section_start', [ $this, 'posts_register_additional_ms_query_control' ], 10, 2 );
 
-		add_action( 'elementor_pro/posts/query/multisite', [ $this, 'add_ms_query'], 10, 2 );
-		add_action( 'elementor_pro/portfolio/query/multisite', [ $this, 'add_ms_query'], 10, 2 );
+		add_action( 'elementor/query/multisite', [ $this, 'add_ms_query'], 10, 2 );
 
 	}
 }


### PR DESCRIPTION
Having some deprecated notices, I am replacing the query hooks with the new one.
`elementor_pro/posts/query/multisite is <strong>deprecated</strong> since version 2.5.0! Use elementor/query/multisite instead`

See doc:
https://developers.elementor.com/custom-query-filter/